### PR TITLE
CASMTRIAGE-3600 Make 15.2 SLES image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-FROM registry.suse.com/suse/sle15:15.2 AS base
+FROM  artifactory.algol60.net/csm-docker/stable/docker.io/opensuse/leap:15.2 as base
 
 ARG user=jenkins
 ARG group=jenkins
@@ -28,19 +28,6 @@ ARG gid=10000
 
 ENV HOME /home/${user}
 RUN groupadd -g ${gid} ${group} && useradd -l -c "Jenkins USER" -d $HOME -u ${uid} -g ${gid} -m ${user}
-
-# No repositories are defined in SP2, and there is no SP2 version of this repo:
-RUN zypper addrepo https://updates.suse.com/SUSE/Products/SLE-BCI/15-SP3/x86_64/product/ SLE_BCI
-
-RUN zypper --non-interactive install --no-recommends --force-resolution SUSEConnect \
-    && zypper clean -a \
-    && zypper rr SLE_BCI
-
-RUN --mount=type=secret,id=SLES_REGISTRATION_CODE SUSEConnect -r "$(cat /run/secrets/SLES_REGISTRATION_CODE)"
-
-RUN SUSEConnect -p sle-module-desktop-applications/15.2/x86_64 \
-    && SUSEConnect -p sle-module-development-tools/15.2/x86_64 \
-    && SUSEConnect -p sle-module-containers/15.2/x86_64
 
 CMD ["/bin/bash"]
 FROM base as product
@@ -61,7 +48,6 @@ RUN zypper refresh \
         libtool \
         make \
         ncurses-devel \
-        openssh \
         openssl \
         pam-devel \
         readline-devel \
@@ -75,6 +61,5 @@ RUN zypper refresh \
         xz-devel \
         zlib-devel \
         && zypper clean -a \
-        && SUSEConnect --cleanup
 
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,6 @@ RUN zypper refresh \
         sqlite3-devel \
         unzip \
         util-linux \
-        vim \
         which \
         xz-devel \
         zlib-devel \


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: [CASMTRIAGE-3600](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3600)

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This produces a SP2 docker build environment with an older GLIBC:

```bash
glibc-2.26-lp152.26.12.1.x86_64
```

This enables Python applications that require libc to build for a broader set of target OSes.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->

None.