### PR TITLE
Prevent hadolint from deactivating

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -10,12 +10,14 @@ name: Hadolint
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - 'maint/**'
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
-  schedule:
-    - cron: '16 1 * * 1'
+    branches:
+      - main
+      - 'maint/**'
 
 permissions:
   contents: read

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -56,7 +56,7 @@ pipeline {
         MULTI_ARCH = 1
         NAME = getRepoName()
         TIMESTAMP = sh(returnStdout: true, script: "date '+%Y%m%d%H%M%S'").trim()
-        SLES_VERSION = sh(returnStdout: true, script: "awk -F ':' '/^FROM/{print \$NF; exit}' Dockerfile | awk '{print \$1}'").trim()
+        SLE_VERSION = sh(returnStdout: true, script: "awk -F ':' '/^FROM/{print \$NF; exit}' Dockerfile | awk '{print \$1}'").trim()
         VERSION = "${GIT_COMMIT[0..6]}"
     }
 
@@ -73,6 +73,10 @@ pipeline {
         }
 
         stage('Publish') {
+            environment {
+                SLES_REGISTRATION_CODE = credentials('sles15-registration-code')
+                BUILD_ARGS = "--build-arg 'SLE_VERSION=${SLE_VERSION}' --secret id=SLES_REGISTRATION_CODE"
+            }
             steps {
                 script {
 
@@ -80,21 +84,21 @@ pipeline {
                     if (isStable) {
                         /*
                         Publish these tags on stable:
-                            - Major.Minor-Hash-Timestamp    (e.g. 15.3-dhckj3-20221017133121)
-                            - Major.Minor-Hash-Timestamp    (e.g. 15.3-dhckj3)
-                            - Major.Minor                   (e.g. 15.3)
+                            - Major.Minor-Hash-Timestamp    (e.g. 15.4-dhckj3-20221017133121)
+                            - Major.Minor-Hash-Timestamp    (e.g. 15.4-dhckj3)
+                            - Major.Minor                   (e.g. 15.4)
                         */
-                        publishCsmDockerImage(image: env.NAME, tag: "${env.SLES_VERSION}", multiArch: env.MULTI_ARCH, isStable: isStable)
-                        publishCsmDockerImage(image: env.NAME, tag: "${env.SLES_VERSION}-${env.VERSION}", multiArch: env.MULTI_ARCH, isStable: isStable)
-                        publishCsmDockerImage(image: env.NAME, tag: "${env.SLES_VERSION}-${env.VERSION}-${env.TIMESTAMP}", multiArch: env.MULTI_ARCH, isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, multiArch: env.MULTI_ARCH, isStable: isStable, tag: "${env.SLE_VERSION}")
+                        publishCsmDockerImage(image: env.NAME, multiArch: env.MULTI_ARCH, isStable: isStable, tag: "${env.SLE_VERSION}-${env.VERSION}")
+                        publishCsmDockerImage(image: env.NAME, multiArch: env.MULTI_ARCH, isStable: isStable, tag: "${env.SLE_VERSION}-${env.VERSION}-${env.TIMESTAMP}")
                     } else {
                         /*
                         Publish these tags on unstable:
                             - Hash                          (e.g. dhckj3)
                             - Hash-Timestamp                (e.g. dhckj3-20221017133121)
                         */
-                        publishCsmDockerImage(image: env.NAME, tag: "${env.VERSION}", multiArch: env.MULTI_ARCH, isStable: isStable)
-                        publishCsmDockerImage(image: env.NAME, tag: "${env.VERSION}-${env.TIMESTAMP}", multiArch: env.MULTI_ARCH, isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, multiArch: env.MULTI_ARCH, isStable: isStable, tag: "${env.VERSION}")
+                        publishCsmDockerImage(image: env.NAME, multiArch: env.MULTI_ARCH, isStable: isStable, tag: "${env.VERSION}-${env.TIMESTAMP}")
                     }
                 }
             }

--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,10 @@ The provided `Makefile` adds Jenkins Pipeline variables to the `docker build` co
 ----
 export DOCKER_BUILDKIT=1
 export SLES_REGISTRATION_CODE=<registration_code>
-docker build --secret id=SLES_REGISTRATION_CODE .
+
+make image
+
+docker run -it csm-docker-sle:15.4
 ----
 
 == Running


### PR DESCRIPTION
The cron trigger is not necessary for hadolint since it only lints the `Dockerfile` and isn't doing any security scanning.

If this repo goes 60 days without activity, the presence of the cron trigger will cause the hadolint workflow to be deactivated. This means PRs made after 60 days of activity will not get linted.
