### PR TITLE
Prevent hadolint from deactivating

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -10,12 +10,14 @@ name: Hadolint
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - 'maint/**'
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
-  schedule:
-    - cron: '16 1 * * 1'
+    branches:
+      - main
+      - 'maint/**'
 
 permissions:
   contents: read

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,18 @@
+#
 # MIT License
-# 
-# (C) Copyright [2021-2022] Hewlett Packard Enterprise Development LP
-# 
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
 # to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense,
 # and/or sell copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included
 # in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -19,12 +20,25 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-NAME ?= ${NAME}
-DOCKER_BUILDKIT ?= ${DOCKER_BUILDKIT}
-SLES_VERSION := ${SLES_VERSION}
-VERSION ?= ${VERSION}
+#
+ifeq ($(NAME),)
+export NAME := $(shell basename $(shell pwd))
+endif
+
+ifeq ($(DOCKER_BUILDKIT),)
+export DOCKER_BUILDKIT ?= 1
+endif
+
+ifeq ($(GO_VERSION),)
+export GO_VERSION := $(shell awk -v replace="'" '/goVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
+endif
+
 ifeq ($(TIMESTAMP),)
-TIMESTAMP := $(shell date '+%Y%m%d%H%M%S')
+export TIMESTAMP := $(shell date '+%Y%m%d%H%M%S')
+endif
+
+ifeq ($(VERSION),)
+export VERSION ?= $(shell git rev-parse --short HEAD)
 endif
 
 all: image

--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,10 @@ The provided `Makefile` adds Jenkins Pipeline variables to the `docker build` co
 ----
 export DOCKER_BUILDKIT=1
 export SLES_REGISTRATION_CODE=<registration_code>
-docker build --secret id=SLES_REGISTRATION_CODE .
+
+make image
+
+docker run -it csm-docker-sle:15.4
 ----
 
 == Running


### PR DESCRIPTION
The cron trigger is not necessary for hadolint since it only lints the `Dockerfile` and isn't doing any security scanning.

If this repo goes 60 days without activity, the presence of the cron trigger will cause the hadolint workflow to be deactivated. This means PRs made after 60 days of activity will not get linted.
