### PR TITLE
Add `jq` and more

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN zypper refresh \
         gcc-c++ \
         gdbm-devel \
         git \
+        jq \
         libopenssl-devel \
         libpcap-devel \
         libtool \
@@ -58,9 +59,11 @@ RUN zypper refresh \
         rsync \
         skopeo \
         sqlite3-devel \
+        sudo \
         unzip \
         util-linux \
         vim \
+        wget \
         which \
         xz-devel \
         zlib-devel \


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
The other branches for 15.4 and 15.5 have `jq`, `sudo`, and `wget`. Currently when I use 15.2 in a matrix with 15.4 and 15.5 I have a need for `jq`, that build is failing on 15.2 due to `jq` not being present.

This PR makes 15.2 consistent with the other SLES distros.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
