### PR TITLE
MTL-2232 Install `bundler` with `gem`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN zypper --gpg-auto-import-keys refresh \
         rpm-build \
         rpmlint \
         rsync \
-        ruby2.5-rubygem-bundler \
+        ruby2.5 \
         skopeo \
         sqlite3-devel \
         sudo \
@@ -92,5 +92,8 @@ RUN zypper --gpg-auto-import-keys refresh \
 
 # Install git-vendor
 RUN curl -sSL https://git.io/vzN5m | sudo bash /dev/stdin
+
+# Install bundler (can't use Zypper, latest bundler is <v2).
+RUN gem install bundler:2.3.2
 
 WORKDIR /build


### PR DESCRIPTION
The RPM `bundler` is too old (<v2), and most projects using `bundler` need version 2.

Just install `ruby2.5`, and then install `bundler` via gem to fetch a 2.0 version that's compatible with `ruby2.5`.

```bash
72c6cc15a2e7:/build/fawkes # make .bundle
bundle config --local path .bundle/gems
Traceback (most recent call last):
	2: from /usr/bin/bundle:23:in `<main>'
	1: from /usr/lib64/ruby/2.5.0/rubygems.rb:303:in `activate_bin_path'
/usr/lib64/ruby/2.5.0/rubygems.rb:284:in `find_spec_for_exe': Could not find 'bundler' (2.3.26) required by your /build/fawkes/Gemfile.lock. (Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:2.3.26`
make: *** [Makefile:46: .bundle] Error 1
```