### PR TITLE
MTL-2406 Add `binutils` packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,9 @@ RUN zypper --gpg-auto-import-keys refresh \
     && zypper --non-interactive install --no-recommends --force-resolution \
         autoconf \
         automake \
+        binutils \
+        binutils-devel \
+        binutils-gold \
         createrepo_c \
         curl \
         docker \


### PR DESCRIPTION
Adds `binutils-devel` and `binutils-gold` to resolve arm64 build issues for some languages that require `ld`.