### PR TITLE
Copyright and vars 15.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ export DOCKER_BUILDKIT ?= 1
 endif
 
 ifeq ($(BUILD_ARGS),)
-export BUILD_ARGS ?= "--build-arg 'SLE_VERSION=${SLE_VERSION}' --secret id=SLES_REGISTRATION_CODE"
+export BUILD_ARGS ?= --build-arg 'SLE_VERSION=${SLE_VERSION}' --secret id=SLES_REGISTRATION_CODE
 endif
 
 ifeq ($(SLE_VERSION),)


### PR DESCRIPTION
Updates the copyright in `Dockerfile` from the recent PRs.

Also resolves a local build issue when `BUILD_ARGS` is unset and the `Makefile` uses its default values, the build fails due to the quotes in `BUILD_ARGS`.

```bash
[759]rusty@HPE-XHD22YD7DW:~/gitstuffs/cray-shasta/csm-docker-sle> make image
Name                : csm-docker-sle
DOCKER_BUILDKIT     : 1
SLE Version         : 15.4
Timestamp           : 20240708153448
Version             : b31721f
docker buildx build \
		"--build-arg 'SLE_VERSION=15.4' --secret id=SLES_REGISTRATION_CODE" \
		 \
		--cache-to type=local,dest=docker-build-cache  \
        --platform linux/amd64,linux/arm64 \
        --builder $(docker buildx create --platform linux/amd64,linux/arm64) \
        --pull \
        .
unknown flag: --build-arg 'SLE_VERSION
See 'docker buildx build --help'.
make: *** [image] Error 125
```
