### PR TITLE
MTL-2426 -- Remove ENV LC_ALL=POSIX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ ARG gid=10000
 ENV HOME=/home/${user}
 RUN groupadd -g ${gid} ${group} && useradd -l -c "Jenkins USER" -d $HOME -u ${uid} -g ${gid} -m ${user}
 
-ENV LC_ALL=POSIX
 RUN sed -i -E "s/^.*(rpm\.install\.excludedocs).*/\1 = yes/" /etc/zypp/zypp.conf
 
 RUN zypper --non-interactive install --no-recommends --force-resolution suseconnect-ng \


### PR DESCRIPTION
### Summary and Scope

Removes *ENV LC_ALL=POSIX*
This was missed in maint/15.5 and maint/15.4. All other branches have this line removed.
https://jira-pro.it.hpe.com:8443/browse/MTL-2426

#### Issue Type

- Bugfix Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)