### PR TITLE
Add gcc14 RPM -- 15.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN zypper --gpg-auto-import-keys refresh \
         curl \
         docker \
         gcc \
+        gcc14 \
         gcc-c++ \
         gdbm-devel \
         git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,8 @@ RUN if [ "$TARGETARCH" = 'arm64' ]; then SUSEConnect -p "PackageHub/${SLE_VERSIO
 RUN if [ "$TARGETARCH" = 'amd64' ]; then SUSEConnect -p "PackageHub/${SLE_VERSION}/x86_64" ; fi
 RUN if [ "$TARGETARCH" = 'arm64' ]; then SUSEConnect -p "sle-module-web-scripting/${SLE_VERSION}/aarch64" ; fi
 RUN if [ "$TARGETARCH" = 'amd64' ]; then SUSEConnect -p "sle-module-web-scripting/${SLE_VERSION}/x86_64" ; fi
+RUN if [ "$TARGETARCH" = 'amd64' ]; then SUSEConnect -p "sle-module-desktop-applications/${SLE_VERSION}/x86_64" ; fi
+RUN if [ "$TARGETARCH" = 'arm64' ]; then SUSEConnect -p "sle-module-desktop-applications/${SLE_VERSION}/aarch64" ; fi
 RUN if [ "$TARGETARCH" = 'amd64' ]; then SUSEConnect -p "sle-module-development-tools/${SLE_VERSION}/x86_64" ; fi
 RUN if [ "$TARGETARCH" = 'arm64' ]; then SUSEConnect -p "sle-module-development-tools/${SLE_VERSION}/aarch64" ; fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,8 @@ RUN if [ "$TARGETARCH" = 'arm64' ]; then SUSEConnect -p "PackageHub/${SLE_VERSIO
 RUN if [ "$TARGETARCH" = 'amd64' ]; then SUSEConnect -p "PackageHub/${SLE_VERSION}/x86_64" ; fi
 RUN if [ "$TARGETARCH" = 'arm64' ]; then SUSEConnect -p "sle-module-web-scripting/${SLE_VERSION}/aarch64" ; fi
 RUN if [ "$TARGETARCH" = 'amd64' ]; then SUSEConnect -p "sle-module-web-scripting/${SLE_VERSION}/x86_64" ; fi
+RUN if [ "$TARGETARCH" = 'amd64' ]; then SUSEConnect -p "sle-module-development-tools/${SLE_VERSION}/x86_64" ; fi
+RUN if [ "$TARGETARCH" = 'arm64' ]; then SUSEConnect -p "sle-module-development-tools/${SLE_VERSION}/aarch64" ; fi
 
 CMD ["/bin/bash"]
 FROM base AS product


### PR DESCRIPTION
### Summary and Scope

Add gcc14 RPM.
Background: We updated ipxe code from upstream and the latest code requires a newer version of gcc to build ipxe for arm64