### PR TITLE
Remove docker from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,12 +37,3 @@ updates:
     labels:
       - "github_actions"
       - "dependencies"
-  - package-ecosystem: "docker"
-    # Look for a `Dockerfile` in the `root` directory
-    directory: "/"
-    # Check for updates once a week
-    schedule:
-      interval: "weekly"
-    labels:
-      - "docker"
-      - "dependencies"


### PR DESCRIPTION
We want to maintain the `FROM` lines in our branches here as static sles versions, and do not need dependabot to make PRs to update them.
